### PR TITLE
Adds clarification around DID Docs when anchoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,13 +627,13 @@
             or they can create a child namespace for peer DIDs beneath their own ("did:peer:abc123" -->
             did:xyz:peer:abc123").</p>
         <p>If a peer DID is registered and grafted into another DID namespace, using either method,
-            a decision must be made about which version of the DID Doc is normative: the one registered on
-            that blockchain, one registered on another blockchain, or one not registered on a blockchain
-            at all. Ideally, there would be no difference between the DID Docs stored in each place,
+            the result is two DIDs with different namespaces one peer and one anchored, each with
+            its own DID Doc. A decision must be made about which DID is normative for the relationship,
+            or whether both should continue to be used. If both will be used, it should be understood that
+            the two DID Docs hold keys and other data for two different DIDs, regardless of the shared
+            history of those DIDs. Ideally, there would be no difference between the DID Docs stored in each place,
             but even with the best intentions of the DID controller, differences may arise.
-            This could be achieved by freezing the DID Doc at the moment when it is cross registered,
-            or it may be achieved by selecting one DID Doc as the primary version and making all other
-            DID Docs point to the primary DID Doc.</p>
+            This could be prevented by freezing the DID Doc at the moment when it is registered.</p>
         <p>One reason why this grafting and cross-registering feature is interesting is that peer DIDs
             could be supported by existing DID tools (e.g., the universal resolver) that require a
             blockchain, without any retooling.</p>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <h2>Pairwise, N-wise</h2>
             <p>The omnipresence of peer relationships raises the possibility of DIDs that are only resolvable and usable
                 by peers within the context of a given relationship. Such <a href="http://bit.ly/2BhEPC2">pairwise</a> or 
-                <a href="http://bit.ly/2Qr2BGc"> n-wise</a> identifiers can still have all the other characterstics that 
+                <a href="http://bit.ly/2Qr2BGc"> n-wise</a> identifiers can still have all the other characteristics that
                 make DIDs useful -- DID Documents, endpoints, keys, authorizations, interoperability, and tooling.</p>
             <section>
             <h3>Guarantees</h3>
@@ -199,7 +199,7 @@
             <p>The namestring that shall identify this DID method is: <code>peer</code></p>
             <p>A DID that uses this method MUST begin with the following prefix: <code>did:peer</code>.
                 Per the DID specification, this string MUST be in lowercase. The remainder of the DID, after the prefix,
-                is the NSI specified below.</p>
+                is the namespace specific identifier specified below.</p>
             <p>Early feedback on this method suggested that we embed it beneath the namespace of a particular blockchain,
             as in <code>did:sov:peer</code> or <a
             target="_blank" href="https://w3c-ccg.github.io/didm-veres-one/#veres-one-did-format"><code>did:v1:nym</code></a>.
@@ -255,8 +255,8 @@
                 an analogous keypair on a different curve), and then selecting as the NSI a subset of the public
                 verification key that is at least 128 bits, and that is dependent on <code>keyfmtchar</code>. For
                 <code>keyfmtchar</code> = "1", the NSI = the most significant 16 bytes of the public verification key.</p>
-            <p>In this way, the DID can be known to begin its existence already associated with keys, and the owner
-                of the new DID is guaranteed to be the only entity in the world who possesses the private key.
+            <p>In this way, the DID can be known to begin its existence already associated with keys, and the controller
+                of the new DID can immediately assert they are the only entity in the world who possesses the private key.
                 This guarantees the initial integrity of the DID's chain of custody.
             </p>
         </section>
@@ -370,7 +370,7 @@
                     and because it can be sent over insecure channels, establishing DID relationships has an
                     extremely low bar. This is vital to the virality of SSI.</li>
                     <li>The invitation identifies an endpoint over which the
-                        connecting can occur, but it does not communicate peer keys or a peer DID from the inviter,
+                        connection can occur, but it does not communicate peer keys or a peer DID from the inviter,
                         and the endpoint that the inviter uses (as well as the inviter's DID and keys) are only
                         transmitted once security and privacy are guaranteed.</li>
                     <li>The protocol can be used by parties using any DID method. One of the parties can be using
@@ -477,7 +477,7 @@
                 may know details that the other party lacks. The sender picks a point in time, <code>delta_time</code>,
                 where it believes it and the receiver were probably in sync; it then describes the <a target="_blank"
                 href="https://github.com/hyperledger/indy-hipe/blob/d014879d/text/conn-mgmt-protocols/README.md#did-doc-deltas">deltas</a>
-                that it know about, that have happened since.</p>
+                that it knows about, that have happened since.</p>
                 <p>If the recipient already has the same state, it replies with an <a target="_blank"
                 href="https://github.com/hyperledger/indy-hipe/blob/518b5a9a/text/acks/README.md">ACK</a>.</p>
                 <p>If the recipient knew about a subset of the delta, but not all of it, it applies what is left of the
@@ -577,7 +577,7 @@
             <b>privs</b> = a string that enumerates the privileges being granted.
                 This string is list-like, but is not modeled using a JSON list or dict
                 because of some specialized syntax that conflicts with canonicalization
-                requirements. Its format is space-delimited list of privileges, where each
+                requirements. Its format is a space-delimited list of privileges in string form, where each
                 privilege is an op code name. The list must be sorted in ascending
                 alphabetical order to aid normalization.
             </p>
@@ -621,7 +621,7 @@
     <section>
         <h2>Grafting Peer DIDs Into Another DID Method Namespace</h2>
         <p>Because peer DIDs are guaranteed to be globally unique at the moment of creation,
-            their 128-bit NSI will not exist on any other blockchain. Blockchain-based DID methods
+            their 128-bit NSI should not exist on any blockchain. Blockchain-based DID methods
             can register a peer DID Doc using their own method. As the DID value, they can either
             combine their own method prefix with peer DID's NSI ("did:peer:abc123" --> "did:xyz:abc123"),
             or they can create a child namespace for peer DIDs beneath their own ("did:peer:abc123" -->
@@ -629,8 +629,11 @@
         <p>If a peer DID is registered and grafted into another DID namespace, using either method,
             a decision must be made about which version of the DID Doc is normative: the one registered on
             that blockchain, one registered on another blockchain, or one not registered on a blockchain
-            at all. Ideally, there would be no difference between the DID Docs stored in each place.
-            This could be achieved by freezing the DID Doc at the moment when it is cross registered.</p>
+            at all. Ideally, there would be no difference between the DID Docs stored in each place,
+            but even with the best intentions of the DID controller, differences may arise.
+            This could be achieved by freezing the DID Doc at the moment when it is cross registered,
+            or it may be achieved by selecting one DID Doc as the primary version and making all other
+            DID Docs point to the primary DID Doc.</p>
         <p>One reason why this grafting and cross-registering feature is interesting is that peer DIDs
             could be supported by existing DID tools (e.g., the universal resolver) that require a
             blockchain, without any retooling.</p>
@@ -647,7 +650,7 @@
                 javascript with no Indy dependencies</a>.</p>
         <p>The connection protocol that creates and registers peer DIDs, including support for DID resolution
             after connection, has been fully implemented by
-        half a dozen different organizations, as of March 2019. One of these organizations is not using
+        half a dozen different organizations, as of March 2019. One of these organizations did not use
         libindy. The connection management protocols that allow update of DIDs are in various states of
         implementation. An up-to-date summary of implementation status, including links to the implementations,
             can be found in the <a target="_blank" href="https://github.com/hyperledger/indy-agent">indy-agent repo on github</a>.</p>
@@ -656,10 +659,10 @@
 
     <section>
         <h2>Resources</h2>
-        <p>Developers maintaining this spec and its reference implementations are often found on RocketChat a
-            chat.hyperledger.org, #indy and #indy-sdk. You might also connect with them via the Hyperledger Indy
-            mailing list at indy@lists.hyperledger.org, or in Hyperledger and W3C working
-            groups, or at the semi-annual Internet Identity Workshop conferences.</p>
+        <p>Developers maintaining this spec and its reference implementations are often found on RocketChat at
+            chat.hyperledger.org, #indy, #indy-sdk, and #aries. You might also connect with them via the Hyperledger Indy
+            mailing list at indy@lists.hyperledger.org, the Hyperledger Aries mailing list at aries@lists.hyperledger.org,
+            in Hyperledger and W3C working groups, or at the semi-annual Internet Identity Workshop conferences.</p>
     </section>
 
   </body>

--- a/index.html
+++ b/index.html
@@ -679,13 +679,12 @@
             or they can create a child namespace for peer DIDs beneath their own ("did:peer:abc123" -->
             did:xyz:peer:abc123").</p>
         <p>If a peer DID is registered and grafted into another DID namespace, using either method,
-            the result is two DIDs with different namespaces one peer and one anchored, each with
+            the result is two DIDs with different namespaces, one peer and one anchored, each with
             its own DID Doc. A decision must be made about which DID is normative for the relationship,
             or whether both should continue to be used. If both will be used, it should be understood that
             the two DID Docs hold keys and other data for two different DIDs, regardless of the shared
             history of those DIDs. Ideally, there would be no difference between the DID Docs stored in each place,
-            but even with the best intentions of the DID controller, differences may arise.
-            This could be prevented by freezing the peer DID Doc at the moment when it is registered.</p>
+            but even with the best intentions of the DID controller, differences may arise.</p>
         <p>One reason why this grafting and cross-registering feature is interesting is that peer DIDs
             could be supported by existing DID tools (e.g., the universal resolver) that require a
             blockchain, without any retooling.</p>

--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@
             the two DID Docs hold keys and other data for two different DIDs, regardless of the shared
             history of those DIDs. Ideally, there would be no difference between the DID Docs stored in each place,
             but even with the best intentions of the DID controller, differences may arise.
-            This could be prevented by freezing the DID Doc at the moment when it is registered.</p>
+            This could be prevented by freezing the peer DID Doc at the moment when it is registered.</p>
         <p>One reason why this grafting and cross-registering feature is interesting is that peer DIDs
             could be supported by existing DID tools (e.g., the universal resolver) that require a
             blockchain, without any retooling.</p>


### PR DESCRIPTION
Adds clarifying text about DID Docs when anchoring a peer DID to a verifiable data registry (and ending up with multiple DID Docs).
Also some minor edits and added mention of aries.

Signed-off-by: Brent <brent.zundel@gmail.com>