### PR TITLE
Changed two occurrences of "stored version" to "stored variant"

### DIFF
--- a/did-docs.html
+++ b/did-docs.html
@@ -316,7 +316,7 @@
         <h4 id="deleting-a-publickey">Deleting a key</h4>
 
         <p>Any key can be deleted by appending its <code>id</code> to the <code>deleted</code> list at the root of
-            the stored version of a peer DID doc, and by removing its corresponding entry from the <code>publicKey</code>
+            the stored variant of a peer DID doc, and by removing its corresponding entry from the <code>publicKey</code>
             section. Only the append-to-<code>deleted</code> operation needs to be represented in the <a>change
             fragment</a>; the corresponding removal from the <code>publicKey</code> section is implied. For example, to
             delete a key with <code>id</code> = <code>izfrNTmQ</code>, your <a>change fragment</a> would look like

--- a/protocols.html
+++ b/protocols.html
@@ -102,7 +102,7 @@
                 endpoint that the inviter supplied in the invitation. This connection request includes a signed
                 version of the <a>resolved variant</a> [TODO: signed variant??] of the <a>genesis version</a> of
                 the invitee's DID doc. The inviter must verify that the received DID was generated according to
-				the <a href="#namestring-generation-method">namestring generation method</a> from the stored version
+				the <a href="#namestring-generation-method">namestring generation method</a> from the stored variant
 				of the received genesis DID Doc. This is to ensure a strong binding between the received DID and
 				the public key(s) contained in the DID Doc, see also: <a href="#proof-of-control">proof of control</a>.
             </li>


### PR DESCRIPTION
I noticed that I wrote "stored version" of the DID Doc rather than "stored variant", which is how it is defined. This also occurred in one other place, where I also changed it.