### PR TITLE
Fix did_resolution/0.1/resolve_result message type.

### DIFF
--- a/protocols.html
+++ b/protocols.html
@@ -170,7 +170,7 @@
         </p>
         <pre class="example" title="A resolve_result message">
 {
-  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/sync-connection/1.0/state_response",
+  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/did_resolution/0.1/resolve_result",
   "@id": "1517207d-f50e-4ed5-a389-6a4986d718e6",
   "~thread": { "thid": "6a4986dd-f50e-4ed5-a389-718e61517207" },
   "did_document": {


### PR DESCRIPTION
This should have been included in https://github.com/openssi/peer-did-method-spec/pull/97, for some reason I missed it back then.