### PR TITLE
make reserved DIDs consistent

### DIFF
--- a/reserved.html
+++ b/reserved.html
@@ -70,7 +70,7 @@
     <dd>No special semantics are defined for these, in the current version of the spec. Implementations or
         particular software packages may define them (or not) according to preference.</dd>
 
-    <dt>The <dfn>corrupted DID</dfn> (did:peer:11:cccc...cccc)</dt>
+    <dt>The <dfn>corrupted DID</dfn> (did:peer:11-cccc...cccc)</dt>
     <dd>This DID should resolve to the string <code>invalid DID doc</code>, triggering JSON deserialization
         errors.</dd>
 
@@ -80,12 +80,12 @@
         message).
     </dd>
 
-    <dt>The <dfn>empty DID</dfn> (did:peer:11:eeee...eeee)</dt>
+    <dt>The <dfn>empty DID</dfn> (did:peer:11-eeee...eeee)</dt>
     <dd>This DID should resolve to a DID doc that is well formed JSON-LD but that contains no keys, no service
         endpoints, and empty containers for other sections. Attempting to interact with such a DID should trigger
         DID Doc validation errors but not raw JSON deserialization errors.</dd>
 
-    <dt>The <dfn>never resolvable DID</dfn> (did:peer:11:ffff...ffff)</dt>
+    <dt>The <dfn>never resolvable DID</dfn> (did:peer:11-ffff...ffff)</dt>
     <dd>This DID is reserved for triggering resolution errors. [[TODO: Markus, what is the equivalent of
         "not found" as a DID resolution error?]]</dd>
 </dl>


### PR DESCRIPTION
Since the majority of these use `-` after the first 2 characters, I submit this assuming they should be consistent.

I wonder if these are all wrong, though, because there is no `-` (or `:`) in the spec, so maybe all those dashes need to be removed (eg `did:peer:110000...0000` for the first one).